### PR TITLE
upgrade chart autodelete-discord to 0.2.0

### DIFF
--- a/charts/autodelete-discord/Chart.yaml
+++ b/charts/autodelete-discord/Chart.yaml
@@ -2,17 +2,17 @@ apiVersion: v2
 name: autodelete-discord
 description: AutoDelete Discord Bot
 type: application
-version: 0.1.2
-appVersion: 0.0.0
+version: 0.2.0
+appVersion: 1.1.0
 keywords:
   - discord
   - bot
   - auto-delete
   - golang
 sources:
-  - https://github.com/lrstanley/autodelete-docker
-  - https://github.com/riking/AutoDelete
+  - 'https://github.com/lrstanley/autodelete-docker'
+  - 'https://github.com/riking/AutoDelete'
 maintainers:
   - name: lrstanley
     email: me@liamstanley.io
-    url: https://liam.sh
+    url: 'https://liam.sh'


### PR DESCRIPTION
- upgrade chart autodelete-discord from `0.1.2` to `0.2.0`
- upgrade `appVersion` from `0.0.0` to `1.1.0`

auto-created from [helm-version-updater](https://github.com/lrstanley/helm-charts/actions/workflows/helm-version-updater.yml) action