### PR TITLE
update chart autodelete-discord from 0.4.1 to 0.5.0

### DIFF
--- a/charts/autodelete-discord/Chart.yaml
+++ b/charts/autodelete-discord/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: autodelete-discord
 description: AutoDelete Discord Bot
 type: application
-version: 0.4.1
-appVersion: 1.1.0
+version: 0.5.0
+appVersion: 1.2.0
 keywords:
   - discord
   - bot


### PR DESCRIPTION
Updating chart `autodelete-discord`:

- Bumping **version** from `0.4.1` to `0.5.0`.
- Bumping **appVersion** from `1.1.0` to `1.2.0`.

Pull request auto-generated by [helm-version-updater](https://github.com/lrstanley/helm-version-updater).