### PR TITLE
update helm-docs from 1.11.2 to 1.11.3

### DIFF
--- a/.github/workflows/helm-docs.yml
+++ b/.github/workflows/helm-docs.yml
@@ -14,7 +14,7 @@ jobs:
         run: |
           set -e
 
-          docker run --rm -v "$PWD:/helm-docs" jnorwood/helm-docs:v1.11.2 --template-files /helm-docs/.github/HELM_README.md.gotmpl
+          docker run --rm -v "$PWD:/helm-docs" jnorwood/helm-docs:v1.11.3 --template-files /helm-docs/.github/HELM_README.md.gotmpl
 
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"


### PR DESCRIPTION
Updating tool [`helm-docs`](https://github.com/norwoodj/helm-docs):

- Bumping **version** from [`1.11.2`](https://github.com/norwoodj/helm-docs/releases/tag/1.11.2) to [`1.11.3`](https://github.com/norwoodj/helm-docs/releases/tag/1.11.3).

Release notes: [link](https://github.com/norwoodj/helm-docs/releases/tag/1.11.3)

Pull request auto-generated by [pr-version-updater](https://github.com/lrstanley/.github/blob/master/.github/workflows/composite-pr-version-updater/action.yml) and [meta-updaters](https://github.com/lrstanley/.github/blob/master/.github/workflows/meta-updaters.yml) action.