### PR TITLE
update chart pgweb from 1.0.5 to 1.0.6

### DIFF
--- a/charts/pgweb/Chart.yaml
+++ b/charts/pgweb/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pgweb
 description: A Helm chart for pgweb
 type: application
-version: 1.0.5
-appVersion: 0.14.0
+version: 1.0.6
+appVersion: 0.14.2
 keywords:
   - postgres
   - database


### PR DESCRIPTION
Updating chart `pgweb`:

- Bumping **version** from `1.0.5` to `1.0.6`.
- Bumping **appVersion** from `0.14.0` to `0.14.2`.

Pull request auto-generated by [helm-version-updater](https://github.com/lrstanley/helm-version-updater).