### PR TITLE
update chart outline from 1.1.0 to 1.2.0

### DIFF
--- a/charts/outline/Chart.yaml
+++ b/charts/outline/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: outline
 description: The outline helm chart to deploy outline in kubernetes clusters.
-version: 1.1.0
-appVersion: 0.72.2
+version: 1.2.0
+appVersion: 0.73.1
 home: https://getoutline.com
 sources:
   - https://github.com/lrstanley/helm-charts


### PR DESCRIPTION
Updating chart `outline`:

- Bumping **version** from `1.1.0` to `1.2.0`.
- Bumping **appVersion** from `0.72.2` to `0.73.1`.

Pull request auto-generated by [helm-version-updater](https://github.com/lrstanley/helm-version-updater).