### PR TITLE
update chart autodelete-discord from 0.6.1 to 0.6.2

### DIFF
--- a/charts/autodelete-discord/Chart.yaml
+++ b/charts/autodelete-discord/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: autodelete-discord
 description: AutoDelete Discord Bot
 type: application
-version: 0.6.1
-appVersion: 1.2.0
+version: 0.6.2
+appVersion: 1.2.1
 keywords:
   - discord
   - bot


### PR DESCRIPTION
Updating chart `autodelete-discord`:

- Bumping **version** from `0.6.1` to `0.6.2`.
- Bumping **appVersion** from `1.2.0` to `1.2.1`.

Pull request auto-generated by [helm-version-updater](https://github.com/lrstanley/helm-version-updater).