### PR TITLE
update chart outline from 1.4.0 to 1.5.0

### DIFF
--- a/charts/outline/Chart.yaml
+++ b/charts/outline/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: outline
 description: The outline helm chart to deploy outline in kubernetes clusters.
-version: 1.4.0
-appVersion: 0.74.0
+version: 1.5.0
+appVersion: 0.75.0
 home: https://getoutline.com
 sources:
   - https://github.com/lrstanley/helm-charts


### PR DESCRIPTION
Updating chart `outline`:

- Bumping **version** from `1.4.0` to `1.5.0`.
- Bumping **appVersion** from `0.74.0` to `0.75.0`.

Pull request auto-generated by [helm-version-updater](https://github.com/lrstanley/helm-version-updater).