### PR TITLE
update helm-docs from v1.12.0 to v1.13.0

### DIFF
--- a/.github/workflows/helm-docs.yml
+++ b/.github/workflows/helm-docs.yml
@@ -28,7 +28,7 @@ jobs:
             docker run --rm \
               -v "$PWD:/helm-docs" \
               -v "/tmp/HELM_README.md.gotmpl:/tmp/HELM_README.md.gotmpl" \
-              jnorwood/helm-docs:v1.12.0 \
+              jnorwood/helm-docs:v1.13.0 \
               --chart-to-generate "charts/$CHART" \
               --template-files /tmp/HELM_README.md.gotmpl
           done


### PR DESCRIPTION
Updating tool [`helm-docs`](https://github.com/norwoodj/helm-docs):

- Bumping **version** from [`v1.12.0`](https://github.com/norwoodj/helm-docs/releases/tag/v1.12.0) to [`v1.13.0`](https://github.com/norwoodj/helm-docs/releases/tag/v1.13.0).

Release notes: [link](https://github.com/norwoodj/helm-docs/releases/tag/v1.13.0)

Pull request auto-generated by [pr-version-updater](https://github.com/lrstanley/.github/blob/master/.github/workflows/composite-pr-version-updater/action.yml) and [meta-updaters](https://github.com/lrstanley/.github/blob/master/.github/workflows/meta-updaters.yml) action.