### PR TITLE
update helm from v3.14.2 to v3.14.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
       - uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78
         with:
-          version: v3.14.2
+          version: v3.14.3
       - name: helm-dependencies
         run: |
           while read -r chart;do


### PR DESCRIPTION
Updating tool [`helm`](https://github.com/helm/helm):

- Bumping **version** from [`v3.14.2`](https://github.com/helm/helm/releases/tag/v3.14.2) to [`v3.14.3`](https://github.com/helm/helm/releases/tag/v3.14.3).

Release notes: [link](https://github.com/helm/helm/releases/tag/v3.14.3)

Pull request auto-generated by [pr-version-updater](https://github.com/lrstanley/.github/blob/master/.github/workflows/composite-pr-version-updater/action.yml) and [meta-updaters](https://github.com/lrstanley/.github/blob/master/.github/workflows/meta-updaters.yml) action.