### PR TITLE
update helm from v3.14.4 to v3.15.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
       - uses: azure/setup-helm@b7246b12e77f7134dc2d460a3d5bad15bbe29390
         with:
-          version: v3.14.4
+          version: v3.15.2
       - name: helm-dependencies
         run: |
           while read -r chart;do


### PR DESCRIPTION
Updating tool [`helm`](https://github.com/helm/helm):

- Bumping **version** from [`v3.14.4`](https://github.com/helm/helm/releases/tag/v3.14.4) to [`v3.15.0`](https://github.com/helm/helm/releases/tag/v3.15.0).

Release notes: [link](https://github.com/helm/helm/releases/tag/v3.15.0)

Pull request auto-generated by [pr-version-updater](https://github.com/lrstanley/.github/blob/master/.github/workflows/composite-pr-version-updater/action.yml) and [meta-updaters](https://github.com/lrstanley/.github/blob/master/.github/workflows/meta-updaters.yml) action.