### PR TITLE
update chart outline from 1.6.0 to 1.7.0

### DIFF
--- a/charts/outline/Chart.yaml
+++ b/charts/outline/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: outline
 description: The outline helm chart to deploy outline in kubernetes clusters.
-version: 1.6.0
-appVersion: 0.76.1
+version: 1.7.0
+appVersion: 0.77.0
 home: https://getoutline.com
 sources:
   - https://github.com/lrstanley/helm-charts


### PR DESCRIPTION
Updating chart `outline`:

- Bumping **version** from `1.6.0` to `1.7.0`.
- Bumping **appVersion** from `0.76.1` to `0.77.0`.

Pull request auto-generated by [helm-version-updater](https://github.com/lrstanley/helm-version-updater).