### PR TITLE
update chart outline from 1.7.0 to 1.7.1

### DIFF
--- a/charts/outline/Chart.yaml
+++ b/charts/outline/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: outline
 description: The outline helm chart to deploy outline in kubernetes clusters.
-version: 1.7.0
-appVersion: 0.77.0
+version: 1.7.1
+appVersion: 0.77.1
 home: https://getoutline.com
 sources:
   - https://github.com/lrstanley/helm-charts


### PR DESCRIPTION
Updating chart `outline`:

- Bumping **version** from `1.7.0` to `1.7.1`.
- Bumping **appVersion** from `0.77.0` to `0.77.1`.

Pull request auto-generated by [helm-version-updater](https://github.com/lrstanley/helm-version-updater).