### PR TITLE
update chart pgweb from 1.1.0 to 1.2.0

### DIFF
--- a/charts/pgweb/Chart.yaml
+++ b/charts/pgweb/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pgweb
 description: A Helm chart for pgweb
 type: application
-version: 1.1.0
-appVersion: 0.15.0
+version: 1.2.0
+appVersion: 0.16.1
 keywords:
   - postgres
   - database


### PR DESCRIPTION
Updating chart `pgweb`:

- Bumping **version** from `1.1.0` to `1.2.0`.
- Bumping **appVersion** from `0.15.0` to `0.16.1`.

Pull request auto-generated by [helm-version-updater](https://github.com/lrstanley/helm-version-updater).