### PR TITLE
update helm from v3.15.4 to v3.18.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
       - uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814
         with:
-          version: v3.15.4
+          version: v3.18.0
       - name: helm-dependencies
         run: |
           while read -r chart;do


### PR DESCRIPTION
Updating tool [`helm`](https://github.com/helm/helm):

- Bumping **version** from [`v3.15.4`](https://github.com/helm/helm/releases/tag/v3.15.4) to [`v3.18.0`](https://github.com/helm/helm/releases/tag/v3.18.0).

Release notes: [link](https://github.com/helm/helm/releases/tag/v3.18.0)

Pull request auto-generated by [pr-version-updater](https://github.com/lrstanley/.github/blob/master/.github/workflows/composite-pr-version-updater/action.yml) and [meta-updaters](https://github.com/lrstanley/.github/blob/master/.github/workflows/meta-updaters.yml) action.