### PR TITLE
update chart pgweb from 1.2.0 to 1.2.1

### DIFF
--- a/charts/pgweb/Chart.yaml
+++ b/charts/pgweb/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pgweb
 description: A Helm chart for pgweb
 type: application
-version: 1.2.0
-appVersion: 0.16.1
+version: 1.2.1
+appVersion: 0.16.2
 keywords:
   - postgres
   - database


### PR DESCRIPTION
Updating chart `pgweb`:

- Bumping **version** from `1.2.0` to `1.2.1`.
- Bumping **appVersion** from `0.16.1` to `0.16.2`.

Pull request auto-generated by [helm-version-updater](https://github.com/lrstanley/helm-version-updater).