### PR TITLE
fix(outline): support for multiple replicas

### DIFF
--- a/charts/outline/templates/deployment.yaml
+++ b/charts/outline/templates/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "outline.labels" . | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
       {{- include "outline.selectorLabels" . | nindent 6 }}

--- a/charts/outline/values.yaml
+++ b/charts/outline/values.yaml
@@ -6,6 +6,9 @@ image:
   # -- the image tag to use. defaults to the appVersion in Chart.yaml.
   tag: ""
 
+# -- number of replicas to run
+replicas: 1
+
 nameOverride: ""
 fullnameOverride: ""
 


### PR DESCRIPTION
## 🚀 Changes proposed by this PR
This pull request includes changes to the `charts/outline` Helm chart to make the number of replicas configurable. 


### 🧰 Type of change

<!-- REQUIRED: Please mark which one applies to this change, ❌ remove the others. -->
- [x] New feature (non-breaking change which adds functionality).

### 🤝 Requirements

- [x] ✍ I have read and agree to this projects [Code of Conduct](../../blob/master/.github/CODE_OF_CONDUCT.md).
- [x] ✍ I have read and agree to this projects [Contribution Guidelines](../../blob/master/.github/CONTRIBUTING.md).
- [x] ✍ I have read and agree to the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] 🔎 I have performed a self-review of my own changes.
- [x] 🎨 My changes follow the style guidelines of this project.

Closes #59 
