### PR TITLE
Update app to version 0.87.3 and rename DATABASE_PASSWORD env var 

### DIFF
--- a/charts/outline/Chart.yaml
+++ b/charts/outline/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: outline
 description: The outline helm chart to deploy outline in kubernetes clusters.
-version: 1.10.0
-appVersion: 0.84.0
+version: 1.11.0
+appVersion: 0.87.3
 home: https://getoutline.com
 sources:
   - https://github.com/lrstanley/helm-charts

--- a/charts/outline/templates/_helpers.tpl
+++ b/charts/outline/templates/_helpers.tpl
@@ -182,16 +182,16 @@ Environment variables passed to the Outline container and related containers.
 {{- end }}
 {{- if .Values.postgresql.enabled }}
 {{- if .Values.postgresql.auth.generate }}
-- name: DATABASE_PASSWORD
+- name: DATABASE_PASS
   valueFrom:
     secretKeyRef:
       name: {{ .Values.postgresql.auth.existingSecret | quote }}
       key: {{ (.Values.postgresql.auth.secretKeys.userPasswordKey | default "password") | quote }}
 - name: DATABASE_URL
-  value: "postgresql://{{ .Values.postgresql.auth.username }}:$(DATABASE_PASSWORD)@{{ .Release.Name }}-postgresql:{{ .Values.postgresql.primary.service.ports.postgresql }}/{{ .Values.postgresql.auth.database }}"
+  value: "postgres://{{ .Values.postgresql.auth.username }}:$(DATABASE_PASS)@{{ .Release.Name }}-postgresql:{{ .Values.postgresql.primary.service.ports.postgresql }}/{{ .Values.postgresql.auth.database }}"
 {{- else if and .Values.postgresql.auth.username .Values.postgresql.auth.password }}
 - name: DATABASE_URL
-  value: "postgresql://{{ .Values.postgresql.auth.username }}:{{ .Values.postgresql.auth.password }}@{{ .Release.Name }}-postgresql:{{ .Values.postgresql.primary.service.ports.postgresql }}/{{ .Values.postgresql.auth.database }}"
+  value: "postgres://{{ .Values.postgresql.auth.username }}:{{ .Values.postgresql.auth.password }}@{{ .Release.Name }}-postgresql:{{ .Values.postgresql.primary.service.ports.postgresql }}/{{ .Values.postgresql.auth.database }}"
 {{- end }}
 {{- end }}
 {{- if .Values.cnpg.enabled }}
@@ -201,24 +201,24 @@ Environment variables passed to the Outline container and related containers.
     secretKeyRef:
       name: {{ .Values.cnpg.auth.existingSecret | quote }}
       key: "username"
-- name: DATABASE_PASSWORD
+- name: DATABASE_PASS
   valueFrom:
     secretKeyRef:
       name: {{ .Values.cnpg.auth.existingSecret | quote }}
       key: "password"
 - name: DATABASE_URL
-  value: "postgresql://$(DATABASE_USERNAME):$(DATABASE_PASSWORD)@{{ include "outline.cnpgName" . }}-rw:5432/{{ .Values.cnpg.database }}"
+  value: "postgres://$(DATABASE_USERNAME):$(DATABASE_PASS)@{{ include "outline.cnpgName" . }}-rw:5432/{{ .Values.cnpg.database }}"
 {{- else if and .Values.cnpg.auth.username .Values.cnpg.auth.password }}
 - name: DATABASE_URL
-  value: "postgresql://{{ .Values.cnpg.auth.username }}:{{ .Values.cnpg.auth.password }}@{{ include "outline.cnpgName" . }}-rw:5432/{{ .Values.cnpg.database }}"
+  value: "postgres://{{ .Values.cnpg.auth.username }}:{{ .Values.cnpg.auth.password }}@{{ include "outline.cnpgName" . }}-rw:5432/{{ .Values.cnpg.database }}"
 {{- else if and .Values.cnpg.auth.username .Values.cnpg.auth.existingSecret }}
-- name: DATABASE_PASSWORD
+- name: DATABASE_PASS
   valueFrom:
     secretKeyRef:
       name: {{ .Values.cnpg.auth.existingSecret | quote }}
       key: "password"
 - name: DATABASE_URL
-  value: "postgresql://{{ .Values.cnpg.auth.username }}:$(DATABASE_PASSWORD)@{{ include "outline.cnpgName" . }}-rw:5432/{{ .Values.cnpg.database }}"
+  value: "postgres://{{ .Values.cnpg.auth.username }}:$(DATABASE_PASS)@{{ include "outline.cnpgName" . }}-rw:5432/{{ .Values.cnpg.database }}"
 {{- end }}
 {{- end }}
 {{- if .Values.minio.enabled }}


### PR DESCRIPTION

## 🚀 Changes proposed by this PR

As of v0.85.0, the DATABASE_URL environment variable is mutually exclusive to DATABASE_HOST / DATABASE_PORT / DATABASE_NAME / DATABASE_USER / DATABASE_PASSWORD (see: https://github.com/outline/outline/pull/9344).

This change renames DATABASE_PASSWORD to DATABASE_PASS, which is the minimum change required to enable using the latest version of the app.

The DATABASE_URL is also changed to the `postgres` protocol to resolve issues with `yarn db:create` not supporting `postgresql`.

### 🔗 Related bug reports/feature requests

Closes #63 
Encompasses #61 

### 🧰 Type of change

- [X] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).


### 📝 Notes to reviewer

I saw the open PR for updating the version (#61) and I bumped the chart version to match since this PR encompasses that one.

### 🤝 Requirements

- [X] ✍ I have read and agree to this projects [Code of Conduct](../../blob/master/.github/CODE_OF_CONDUCT.md).
- [X] ✍ I have read and agree to this projects [Contribution Guidelines](../../blob/master/.github/CONTRIBUTING.md).
- [X] ✍ I have read and agree to the [Developer Certificate of Origin](https://developercertificate.org/).
- [X] 🔎 I have performed a self-review of my own changes.
- [X] 🎨 My changes follow the style guidelines of this project.
- [X] 💬 My changes as properly commented, primarily for hard-to-understand areas.
- [NA] 📝 I have made corresponding changes to the documentation.
- [NA] 🧪 I have included tests (if necessary) for this change.
