### PR TITLE
update chart outline from 2.2.2 to 2.3.0

### DIFF
--- a/charts/outline/Chart.yaml
+++ b/charts/outline/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: outline
 description: The outline helm chart to deploy outline in kubernetes clusters.
-version: 2.2.2
-appVersion: 1.3.0
+version: 2.3.0
+appVersion: 1.5.0
 home: https://getoutline.com
 sources:
   - https://github.com/lrstanley/helm-charts


### PR DESCRIPTION
Updating chart `outline`:

- Bumping **version** from `2.2.2` to `2.3.0`.
- Bumping **appVersion** from `1.3.0` to `1.5.0`.

Pull request auto-generated by [helm-version-updater](https://github.com/lrstanley/helm-version-updater).